### PR TITLE
Add Codeowners files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @EinfachGustaf/smpclaim-maintainers
+.github/CODEOWNERS @EinfachGustaf/core-team
+LICENSE @EinfachGustaf/core-team


### PR DESCRIPTION
This PR adds codeowners files to helps administrate the repo and prs. Also it prevents to change rights or license without take a callback to the specific teams.
Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners